### PR TITLE
atomics-internal: fix _Atomic type errors

### DIFF
--- a/libguile/atomics-internal.h
+++ b/libguile/atomics-internal.h
@@ -34,33 +34,33 @@
 
 #include <stdatomic.h>
 static inline uint32_t
-scm_atomic_subtract_uint32 (uint32_t *loc, uint32_t arg)
+scm_atomic_subtract_uint32 (_Atomic(uint32_t) *loc, uint32_t arg)
 {
   return atomic_fetch_sub (loc, arg);
 }
 static inline _Bool
-scm_atomic_compare_and_swap_uint32 (uint32_t *loc, uint32_t *expected,
+scm_atomic_compare_and_swap_uint32 (_Atomic(uint32_t) *loc, uint32_t *expected,
                                     uint32_t desired)
 {
   return atomic_compare_exchange_weak (loc, expected, desired);
 }
 static inline void
-scm_atomic_set_scm (SCM *loc, SCM val)
+scm_atomic_set_scm (_Atomic(SCM) *loc, SCM val)
 {
   atomic_store (loc, val);
 }
 static inline SCM
-scm_atomic_ref_scm (SCM *loc)
+scm_atomic_ref_scm (_Atomic(SCM) *loc)
 {
   return atomic_load (loc);
 }
 static inline SCM
-scm_atomic_swap_scm (SCM *loc, SCM val)
+scm_atomic_swap_scm (_Atomic(SCM) *loc, SCM val)
 {
   return atomic_exchange (loc, val);
 }
 static inline _Bool
-scm_atomic_compare_and_swap_scm (SCM *loc, SCM *expected, SCM desired)
+scm_atomic_compare_and_swap_scm (_Atomic(SCM) *loc, SCM *expected, SCM desired)
 {
   return atomic_compare_exchange_weak (loc, expected, desired);
 }


### PR DESCRIPTION
Fix a few _Atomic type errors such as

  error: address argument to atomic operation must be a pointer to
  _Atomic type ('gl_uint32_t *' (aka 'unsigned int *') invalid)
